### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/java8-build.yml
+++ b/.github/workflows/java8-build.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: Java 8 CI
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/java8-publish.yml
+++ b/.github/workflows/java8-publish.yml
@@ -5,6 +5,8 @@ on:
   
 jobs:
   publish:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     environment: maven-central
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/filip26/tree-io/security/code-scanning/2](https://github.com/filip26/tree-io/security/code-scanning/2)

To fix the problem, you should add a `permissions` block specifying `contents: read` to the workflow. This can be placed at the workflow root (above or just below the `on:` block, and before `jobs:`). Adding this limits the GitHub Actions token to only read repository contents, thereby adhering to least privilege without impacting normal build/test workflow steps. No changes to structure, step logic, or existing functionality are needed. Only the YAML file .github/workflows/java8-build.yml requires updating.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
